### PR TITLE
Why call update on setup?

### DIFF
--- a/ReflectionView/ReflectionView.m
+++ b/ReflectionView/ReflectionView.m
@@ -163,9 +163,6 @@
     reflectionGap = 4;
     reflectionScale = 0.5;
     reflectionAlpha = 0.5;
-    
-    //update reflection
-    [self update];
 }
 
 - (id)initWithCoder:(NSCoder *)aDecoder


### PR DESCRIPTION
Removed update invocation in setup method. I think there is no need to update on setup as the update procedure is invoked by layoutsubviews afterwards. So the reflection view is drawn twice on loading, which has driven me into some bad performance issues, if we have several reflection views loading at the same time.

Another thing i don't quite understand....

In your documentation you say in static mode you need to take care of calling the update cycle....but in you're code you are doin something different. no matter if the mode is dynamic or static you always draw something. depending on the mode you just do it somehow diffrently (i didn't investigate what exactly you are doin there). in my case the strange thing is, that using the dynamic mode has a better performance than the static one!? pointing to your documentation it should be vice versa?! do i miss something here?
